### PR TITLE
fix-92: Defer loading JSONField 'diff' in queryset

### DIFF
--- a/nautobot_ssot/forms.py
+++ b/nautobot_ssot/forms.py
@@ -24,7 +24,7 @@ class SyncLogEntryFilterForm(BootstrapMixin, forms.ModelForm):
     """Form for filtering SyncLogEntry records."""
 
     q = forms.CharField(required=False, label="Search")
-    sync = forms.ModelChoiceField(queryset=Sync.objects.all(), required=False)
+    sync = forms.ModelChoiceField(queryset=Sync.objects.defer("diff").all(), required=False)
     action = forms.ChoiceField(choices=add_blank_choice(SyncLogEntryActionChoices), required=False)
     status = forms.ChoiceField(choices=add_blank_choice(SyncLogEntryStatusChoices), required=False)
 

--- a/nautobot_ssot/views.py
+++ b/nautobot_ssot/views.py
@@ -24,7 +24,7 @@ from .tables import DashboardTable, SyncTable, SyncTableSingleSourceOrTarget, Sy
 class DashboardView(ObjectListView):
     """Dashboard / overview of SSoT."""
 
-    queryset = Sync.objects.all()
+    queryset = Sync.objects.defer("diff").all()
     table = DashboardTable
     action_buttons = []
     template_name = "nautobot_ssot/dashboard.html"


### PR DESCRIPTION
Addresses issue #92 

This PR resolve two possible `out of sort memory` errors when running against a MySQL databse.
1. Navigating to `Plugins > Single Source of Truth > Dashboard`
2. Navigating to `Plugins > Single Source of Truth > Logs`

Additionally, the page load time is significantly faster.