### PR TITLE
Fix search bar in SSoT Sync Logs

### DIFF
--- a/nautobot_ssot/templates/nautobot_ssot/synclogentry_list.html
+++ b/nautobot_ssot/templates/nautobot_ssot/synclogentry_list.html
@@ -1,13 +1,7 @@
 {% extends 'generic/object_list.html' %}
 
-{% block header %}
-    <div class="row">
-        <div class="col-md-12">
-            <ol class="breadcrumb">
+{% block extra_breadcrumbs %}
                 <li><a href="{% url 'plugins:nautobot_ssot:dashboard' %}">Single Source of Truth</a></li>
                 <li>Sync Logs</li>
-            </ol>
-        </div>
-    </div>
-{% endblock %}
+{% endblock extra_breadcrumbs %}
 {% block title %}SSoT Sync Logs{% endblock %}


### PR DESCRIPTION
This fixes the SSoT Sync Logs page to re-enable the search bar. Just updating the header that is meant for the breadcrumbs to use the extra_breadcrumbs block instead fixes the search bar being hidden.