### PR TITLE
add fix for issue #257

### DIFF
--- a/nautobot_ssot/contrib.py
+++ b/nautobot_ssot/contrib.py
@@ -91,6 +91,12 @@ class NautobotAdapter(DiffSync):
             metadata_for_this_field = getattr(type_hints[parameter_name], "__metadata__", [])
             for metadata in metadata_for_this_field:
                 if isinstance(metadata, CustomFieldAnnotation):
+                    try:
+                        parameters[parameter_name] = database_object.cf[metadata.name]
+                    except KeyError:
+                        # Custom field not in values passed, field should be skipped and value removed from object if set
+                        # To skip or remove value, simply don't set the key in the parameters dict
+                        pass
                     parameters[parameter_name] = database_object.cf[metadata.name]
                     is_custom_field = True
                     break

--- a/nautobot_ssot/contrib.py
+++ b/nautobot_ssot/contrib.py
@@ -91,13 +91,8 @@ class NautobotAdapter(DiffSync):
             metadata_for_this_field = getattr(type_hints[parameter_name], "__metadata__", [])
             for metadata in metadata_for_this_field:
                 if isinstance(metadata, CustomFieldAnnotation):
-                    try:
+                    if metadata.name in database_object.cf:
                         parameters[parameter_name] = database_object.cf[metadata.name]
-                    except KeyError:
-                        # Custom field not in values passed, field should be skipped and value removed from object if set
-                        # To skip or remove value, simply don't set the key in the parameters dict
-                        pass
-                    parameters[parameter_name] = database_object.cf[metadata.name]
                     is_custom_field = True
                     break
             if is_custom_field:


### PR DESCRIPTION
One important note is that instead of the custom field `label` being used, I used the `key` to make it work. Using the label creates a different custom field that isn't registered and then will start throwing out warnings that the the target object doesn't have that field.