### PR TITLE
Add check for missing job_class attribute on 1.x Jobs

### DIFF
--- a/nautobot_ssot/jobs/__init__.py
+++ b/nautobot_ssot/jobs/__init__.py
@@ -43,6 +43,8 @@ def get_data_jobs():
     data_sources = []
     data_targets = []
     for job in sync_jobs:
+        if job.job_class is None or not issubclass(job.job_class, (DataSource, DataTarget)):
+            continue
         if issubclass(job.job_class, DataSource):
             data_sources.append(job)
         if issubclass(job.job_class, DataTarget):

--- a/nautobot_ssot/metrics.py
+++ b/nautobot_ssot/metrics.py
@@ -96,7 +96,10 @@ def metric_sync_operations():
     )
 
     for job in Job.objects.all():
-        if issubclass(job.job_class, (DataSource, DataTarget)):
+        # Skip any jobs that aren't SSoT jobs
+        if job.job_class is None or not issubclass(job.job_class, (DataSource, DataTarget)):
+            continue
+        else:
             last_job_sync = Sync.objects.filter(job_result__job_model_id=job.id).last()
             if last_job_sync and last_job_sync.summary:
                 for operation, value in last_job_sync.summary.items():
@@ -122,7 +125,10 @@ def metric_memory_usage():
     )
 
     for job in Job.objects.all():
-        if issubclass(job.job_class, (DataSource, DataTarget)):
+        # Skip any jobs that aren't SSoT jobs
+        if job.job_class is None or not issubclass(job.job_class, (DataSource, DataTarget)):
+            continue
+        else:
             last_job_sync = Sync.objects.filter(
                 job_result__job_model_id=job.id, source_load_memory_final__isnull=False
             ).last()


### PR DESCRIPTION
We were told through the public Slack that the issue detailed in #248 is still occurring but at a different part of the code. I've added the same check that is done for the `metric_ssot_jobs()` function to the `metric_sync_operations()` and `metric_memory_usage()`. This should hopefully fix the issue now.