### PR TITLE
Add Custom Database Parameter Loader

### DIFF
--- a/docs/dev/jobs.md
+++ b/docs/dev/jobs.md
@@ -121,6 +121,7 @@ from nautobot_ssot.contrib import NautobotAdapter
 
 from your_ssot_app.models import DiffSyncDevice, DiffSyncPrefix, DiffSyncIPAddress
 
+
 class YourSSoTNautobotAdapter(NautobotAdapter):
     top_level = ("device", "prefix")
 

--- a/docs/dev/jobs.md
+++ b/docs/dev/jobs.md
@@ -121,7 +121,6 @@ from nautobot_ssot.contrib import NautobotAdapter
 
 from your_ssot_app.models import DiffSyncDevice, DiffSyncPrefix, DiffSyncIPAddress
 
-
 class YourSSoTNautobotAdapter(NautobotAdapter):
     top_level = ("device", "prefix")
 
@@ -131,6 +130,22 @@ class YourSSoTNautobotAdapter(NautobotAdapter):
 ```
 
 The `load` function is already implemented on this adapter and will automatically and recursively traverse any children relationships for you, provided the models are [defined correctly](../user/modeling.md).
+
+Developers are able to override the default loading of basic parameters to control how that parameter is loaded from Nautobot. 
+
+This only works with basic parameters belonging to the model and does not override more complex parameters (foreign keys, custom fields, custom relationships, etc.).
+
+To override a parameter, simply add a method with the name `load_param_{param_key}` to your adapter class inheriting from `NautobotAdapter`:
+
+```python
+from nautobot_ssot.contrib import NautobotAdapter
+
+class YourSSoTNautobotAdapter(NautobotAdapter):
+    ...    
+    def load_param_time_zone(self, parameter_name, database_object):
+        """Custom loader for `time_zone` parameter."""
+        return str(getattr(database_object, parameter_name))
+```
 
 ### Step 2.2 - Creating the Remote Adapter
 

--- a/nautobot_ssot/contrib.py
+++ b/nautobot_ssot/contrib.py
@@ -119,10 +119,6 @@ class NautobotAdapter(DiffSync):
         self._handle_children(database_object, diffsync_model)
         return diffsync_model
 
-    def load_param_time_zone(self, parameter_name, database_object):
-        """Default loader for `time_zone` parameter."""
-        return str(getattr(database_object, parameter_name))
-
     def _handle_children(self, database_object, diffsync_model):
         """Recurse through all the children for this model."""
         for children_parameter, children_field in diffsync_model._children.items():

--- a/nautobot_ssot/contrib.py
+++ b/nautobot_ssot/contrib.py
@@ -104,7 +104,12 @@ class NautobotAdapter(DiffSync):
                 continue
 
             # Handling of normal fields - as this is the default case, set the attribute directly.
-            parameters[parameter_name] = getattr(database_object, parameter_name)
+            if hasattr(self, f"load_param_{parameter_name}"):
+                parameters[parameter_name] = getattr(self, f"load_param_{parameter_name}")(
+                    parameter_name, database_object
+                )
+            else:
+                parameters[parameter_name] = getattr(database_object, parameter_name)
         try:
             diffsync_model = diffsync_model(**parameters)
         except pydantic.ValidationError as error:
@@ -113,6 +118,10 @@ class NautobotAdapter(DiffSync):
 
         self._handle_children(database_object, diffsync_model)
         return diffsync_model
+
+    def load_param_time_zone(self, parameter_name, database_object):
+        """Default loader for `time_zone` parameter."""
+        return str(getattr(database_object, parameter_name))
 
     def _handle_children(self, database_object, diffsync_model):
         """Recurse through all the children for this model."""


### PR DESCRIPTION
Problem:
As it currently stands, trying to sync the `time_zone` field in `Location` objects from Nautobot does not appear to be supported.
- Loading objects from the database returns a `DstTzInfo` object
- `DstTzInfo` is not JSON serializable and raises an error when used, so cannot be used for SSoT
- Unable to determine existing way to convert the `DstTzInfo` object into a string which can be compared within SSoT
- Unable to override an individual field when loading from the Nautobot adapter

Solution:
This PR provides two solutions:
1. A way for any child class of `NautobotAdapter` to add additional methods to override the default loading of individual fields/parameters (excluding custom fields and relationships). It searches for a method named `load_param_{param_name}`
2. A method for handling the `time_zone` field by converting the `DstTzInfo` class into a string enabling default handling of the `time_zone` field. Any parameter or field without a specified method will be get default handling