### PR TITLE
Fix CloudVision SSoT Jobs

### DIFF
--- a/nautobot_ssot/integrations/aristacv/jobs.py
+++ b/nautobot_ssot/integrations/aristacv/jobs.py
@@ -112,7 +112,7 @@ class CloudVisionDataSource(DataSource, Job):  # pylint: disable=abstract-method
         self.target_adapter = NautobotAdapter(job=self)
         self.target_adapter.load()
 
-    def run(  # pylint: disable=arguments-differ, too-many-arguments
+    def run(  # pylint: disable=arguments-differ, too-many-arguments, duplicate-code
         self, dryrun, memory_profiling, debug, *args, **kwargs
     ):
         """Perform data synchronization."""
@@ -187,7 +187,7 @@ class CloudVisionDataTarget(DataTarget, Job):  # pylint: disable=abstract-method
             self.target_adapter = CloudvisionAdapter(job=self, conn=client)
             self.target_adapter.load()
 
-    def run(  # pylint: disable=arguments-differ, too-many-arguments
+    def run(  # pylint: disable=arguments-differ, too-many-arguments, duplicate-code
         self, dryrun, memory_profiling, debug, *args, **kwargs
     ):
         """Perform data synchronization."""

--- a/nautobot_ssot/integrations/aristacv/jobs.py
+++ b/nautobot_ssot/integrations/aristacv/jobs.py
@@ -112,6 +112,15 @@ class CloudVisionDataSource(DataSource, Job):  # pylint: disable=abstract-method
         self.target_adapter = NautobotAdapter(job=self)
         self.target_adapter.load()
 
+    def run(  # pylint: disable=arguments-differ, too-many-arguments
+        self, dryrun, memory_profiling, debug, *args, **kwargs
+    ):
+        """Perform data synchronization."""
+        self.debug = debug
+        self.dryrun = dryrun
+        self.memory_profiling = memory_profiling
+        super().run(dryrun=self.dryrun, memory_profiling=self.memory_profiling, *args, **kwargs)
+
 
 class CloudVisionDataTarget(DataTarget, Job):  # pylint: disable=abstract-method
     """CloudVision SSoT Data Target."""
@@ -177,6 +186,15 @@ class CloudVisionDataTarget(DataTarget, Job):  # pylint: disable=abstract-method
             self.logger.info("Loading data from CloudVision")
             self.target_adapter = CloudvisionAdapter(job=self, conn=client)
             self.target_adapter.load()
+
+    def run(  # pylint: disable=arguments-differ, too-many-arguments
+        self, dryrun, memory_profiling, debug, *args, **kwargs
+    ):
+        """Perform data synchronization."""
+        self.debug = debug
+        self.dryrun = dryrun
+        self.memory_profiling = memory_profiling
+        super().run(dryrun=self.dryrun, memory_profiling=self.memory_profiling, *args, **kwargs)
 
 
 jobs = [CloudVisionDataSource, CloudVisionDataTarget]


### PR DESCRIPTION
This PR includes the fix for the dry-run issues brought up in #266. Both Jobs were missing run() definition for 2.0 so Job options weren't being passed to the parent Job or other parts of the code for required functionality. Now with this in place the dry-run, debug, and memory profiling options should all work in the CloudVision SSoT integration.