### PR TITLE
Add single network view and IP Address type support

### DIFF
--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -230,6 +230,7 @@ PLUGINS_CONFIG = {
         "infoblox_username": os.getenv("NAUTOBOT_SSOT_INFOBLOX_USERNAME"),
         "infoblox_verify_ssl": is_truthy(os.getenv("NAUTOBOT_SSOT_INFOBLOX_VERIFY_SSL", True)),
         "infoblox_wapi_version": os.getenv("NAUTOBOT_SSOT_INFOBLOX_WAPI_VERSION", "v2.12"),
+        "infoblox_network_view": os.getenv("NAUTOBOT_SSOT_INFOBLOX_NETWORK_VIEW", ""),
         "ipfabric_api_token": os.getenv("NAUTOBOT_SSOT_IPFABRIC_API_TOKEN"),
         "ipfabric_host": os.getenv("NAUTOBOT_SSOT_IPFABRIC_HOST"),
         "ipfabric_ssl_verify": is_truthy(os.getenv("NAUTOBOT_SSOT_IPFABRIC_SSL_VERIFY", "False")),

--- a/docs/admin/integrations/infoblox_setup.md
+++ b/docs/admin/integrations/infoblox_setup.md
@@ -29,6 +29,7 @@ Integration behavior can be controlled with the following settings:
 | infoblox_import_objects_vlan_views         | False   | Import VLAN views from Infoblox to Nautobot.                             |
 | infoblox_import_objects_vlans              | False   | Import VLANs from Infoblox to Nautobot.                                  |
 | infoblox_import_subnets                    | N/A     | List of Subnets in CIDR string notation to filter import to.             |
+| infoblox_network_view                      | N/A     | Import IP addresses only from a specific Network View.                   |
 
 Below is an example snippet from `nautobot_config.py` that demonstrates how to enable and configure Infoblox integration:
 

--- a/docs/admin/integrations/infoblox_setup.md
+++ b/docs/admin/integrations/infoblox_setup.md
@@ -29,7 +29,7 @@ Integration behavior can be controlled with the following settings:
 | infoblox_import_objects_vlan_views         | False   | Import VLAN views from Infoblox to Nautobot.                             |
 | infoblox_import_objects_vlans              | False   | Import VLANs from Infoblox to Nautobot.                                  |
 | infoblox_import_subnets                    | N/A     | List of Subnets in CIDR string notation to filter import to.             |
-| infoblox_network_view                      | N/A     | Import IP addresses only from a specific Network View.                   |
+| infoblox_network_view                      | N/A     | Only load IPAddresses from a specific Infoblox Network View.             |
 
 Below is an example snippet from `nautobot_config.py` that demonstrates how to enable and configure Infoblox integration:
 

--- a/nautobot_ssot/integrations/infoblox/constant.py
+++ b/nautobot_ssot/integrations/infoblox/constant.py
@@ -12,6 +12,7 @@ def _read_plugin_config():
         "NAUTOBOT_INFOBLOX_PASSWORD": config["infoblox_password"],
         "NAUTOBOT_INFOBLOX_VERIFY_SSL": config["infoblox_verify_ssl"],
         "NAUTOBOT_INFOBLOX_WAPI_VERSION": config["infoblox_wapi_version"],
+        "NAUTOBOT_INFOBLOX_NETWORK_VIEW": config["infoblox_network_view"],
         "enable_sync_to_infoblox": config["infoblox_enable_sync_to_infoblox"],
         "enable_rfc1918_network_containers": config["infoblox_enable_rfc1918_network_containers"],
         "default_status": config["infoblox_default_status"],

--- a/nautobot_ssot/integrations/infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/adapters/infoblox.py
@@ -3,6 +3,7 @@ import re
 
 from diffsync import DiffSync
 from diffsync.enum import DiffSyncFlags
+from diffsync.exceptions import ObjectAlreadyExists
 from nautobot.extras.plugins.exceptions import PluginImproperlyConfigured
 from nautobot_ssot.integrations.infoblox.constant import PLUGIN_CFG
 from nautobot_ssot.integrations.infoblox.utils.client import get_default_ext_attrs, get_dns_name
@@ -82,7 +83,14 @@ class InfobloxAdapter(DiffSync):
                 ext_attrs={**default_ext_attrs, **pf_ext_attrs},
                 vlans=build_vlan_map(vlans=_pf["vlans"]) if _pf.get("vlans") else {},
             )
-            self.add(new_pf)
+            try:
+                self.add(new_pf)
+            except ObjectAlreadyExists:
+                self.job.logger.warning(
+                    f"Duplicate prefix found: {new_pf}. Duplicate prefixes are not supported, "
+                    "and only the first occurrence will be included in the sync. To load data "
+                    "from a single Network View, use the 'infoblox_network_view' setting."
+                )
 
     def load_ipaddresses(self):
         """Load InfobloxIPAddress DiffSync model."""

--- a/nautobot_ssot/integrations/infoblox/diffsync/adapters/infoblox.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/adapters/infoblox.py
@@ -100,6 +100,7 @@ class InfobloxAdapter(DiffSync):
                 prefix_length=prefix_length,
                 dns_name=dns_name,
                 status=self.conn.get_ipaddr_status(_ip),
+                ip_addr_type=self.conn.get_ipaddr_type(_ip),
                 description=_ip["comment"],
                 ext_attrs={**default_ext_attrs, **ip_ext_attrs},
             )

--- a/nautobot_ssot/integrations/infoblox/diffsync/adapters/nautobot.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/adapters/nautobot.py
@@ -175,6 +175,7 @@ class NautobotAdapter(NautobotMixin, DiffSync):  # pylint: disable=too-many-inst
                 address=addr,
                 prefix=str(prefix),
                 status=ipaddr.status.name if ipaddr.status else None,
+                ip_addr_type=ipaddr.type,
                 prefix_length=prefix.prefix_length if prefix else ipaddr.prefix_length,
                 dns_name=ipaddr.dns_name,
                 description=ipaddr.description,

--- a/nautobot_ssot/integrations/infoblox/diffsync/models/base.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/models/base.py
@@ -53,13 +53,14 @@ class IPAddress(DiffSyncModel):
 
     _modelname = "ipaddress"
     _identifiers = ("address", "prefix", "prefix_length")
-    _attributes = ("description", "dns_name", "status", "ext_attrs")
+    _attributes = ("description", "dns_name", "status", "ip_addr_type", "ext_attrs")
 
     address: str
     dns_name: str
     prefix: str
     prefix_length: int
     status: Optional[str]
+    ip_addr_type: Optional[str]
     description: Optional[str]
     ext_attrs: Optional[dict]
     pk: Optional[uuid.UUID] = None

--- a/nautobot_ssot/integrations/infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/models/nautobot.py
@@ -39,18 +39,27 @@ def process_ext_attrs(diffsync, obj: object, extattrs: dict):  # pylint: disable
                         f"supported by Nautobot. {err}"
                     )
             if attr.lower() == "vrf":
-                try:
-                    obj.vrfs.add(diffsync.vrf_map[attr_value])
-                except KeyError as err:
-                    diffsync.job.logger.warning(
-                        f"Unable to find VRF {attr_value} for {obj} found in Extensibility Attributes '{attr}'. {err}"
-                    )
-                except TypeError as err:
-                    diffsync.job.logger.warning(
-                        f"Cannot set vrf values {attr_value} for {obj}. Multiple vrfs are assigned "
-                        f"in Extensibility Attributes '{attr}', but multiple vrf assignments are not "
-                        f"supported by Nautobot. {err}"
-                    )
+                if type(attr_value) is list:
+                    for vrf in attr_value:
+                        try:
+                            obj.vrfs.add(diffsync.vrf_map[vrf])
+                        except KeyError as err:
+                            diffsync.job.logger.warning(
+                                f"Unable to find VRF {vrf} for {obj} found in Extensibility Attributes '{attr}'. {err}"
+                            )
+                else:
+                    try:
+                        obj.vrfs.add(diffsync.vrf_map[attr_value])
+                    except KeyError as err:
+                        diffsync.job.logger.warning(
+                            f"Unable to find VRF {attr_value} for {obj} found in Extensibility Attributes '{attr}'. {err}"
+                        )
+                    except TypeError as err:
+                        diffsync.job.logger.warning(
+                            f"Cannot set vrf values {attr_value} for {obj}. Multiple vrfs are assigned "
+                            f"in Extensibility Attributes '{attr}', but multiple vrf assignments are not "
+                            f"supported by Nautobot. {err}"
+                        )
             if "role" in attr.lower():
                 if isinstance(obj, OrmIPAddress) and attr_value.lower() in IPAddressRoleChoices.as_dict():
                     obj.role = attr_value.lower()

--- a/nautobot_ssot/integrations/infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/models/nautobot.py
@@ -23,7 +23,7 @@ def process_ext_attrs(diffsync, obj: object, extattrs: dict):  # pylint: disable
         obj (object): The object that's being created or updated and needs processing.
         extattrs (dict): The Extensibility Attributes to be analyzed and applied to passed `prefix`.
     """
-    for attr, attr_value in extattrs.items():
+    for attr, attr_value in extattrs.items():  # pylint: disable=too-many-nested-blocks
         if attr_value:
             if attr.lower() in ["site", "facility", "location"]:
                 try:
@@ -39,7 +39,7 @@ def process_ext_attrs(diffsync, obj: object, extattrs: dict):  # pylint: disable
                         f"supported by Nautobot. {err}"
                     )
             if attr.lower() == "vrf":
-                if type(attr_value) is list:
+                if isinstance(attr_value, list):
                     for vrf in attr_value:
                         try:
                             obj.vrfs.add(diffsync.vrf_map[vrf])

--- a/nautobot_ssot/integrations/infoblox/diffsync/models/nautobot.py
+++ b/nautobot_ssot/integrations/infoblox/diffsync/models/nautobot.py
@@ -54,12 +54,6 @@ def process_ext_attrs(diffsync, obj: object, extattrs: dict):  # pylint: disable
                         diffsync.job.logger.warning(
                             f"Unable to find VRF {attr_value} for {obj} found in Extensibility Attributes '{attr}'. {err}"
                         )
-                    except TypeError as err:
-                        diffsync.job.logger.warning(
-                            f"Cannot set vrf values {attr_value} for {obj}. Multiple vrfs are assigned "
-                            f"in Extensibility Attributes '{attr}', but multiple vrf assignments are not "
-                            f"supported by Nautobot. {err}"
-                        )
             if "role" in attr.lower():
                 if isinstance(obj, OrmIPAddress) and attr_value.lower() in IPAddressRoleChoices.as_dict():
                     obj.role = attr_value.lower()

--- a/nautobot_ssot/integrations/infoblox/utils/client.py
+++ b/nautobot_ssot/integrations/infoblox/utils/client.py
@@ -792,7 +792,7 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
             "_max_results": 10000,
         }
         if PLUGIN_CFG.get("NAUTOBOT_INFOBLOX_NETWORK_VIEW"):
-            params.update({"network_view": PLUGIN_CFG.get("NAUTOBOT_INFOBLOX_NETWORK_VIEW")})
+            params.update({"network_view": PLUGIN_CFG["NAUTOBOT_INFOBLOX_NETWORK_VIEW"]})
         if prefix:
             params.update({"network": prefix})
         try:
@@ -1173,10 +1173,19 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
 
     @staticmethod
     def get_ipaddr_status(ip_record: dict) -> str:
-        """Determine the IPAddress status based upon types and usage keys."""
+        """Determine the IPAddress status based on the status key."""
+        if "USED" in ip_record["status"]:
+            return "Active"
+        return "Reserved"
+
+    @staticmethod
+    def get_ipaddr_type(ip_record: dict) -> str:
+        """Determine the IPAddress type based on the usage key."""
         if "DHCP" in ip_record["usage"]:
-            return "DHCP"
-        return "Active"
+            return "dhcp"
+        if "SLAAC" in ip_record["usage"]:
+            return "slaac"
+        return "host"
 
     def _find_resource(self, resource, **params):
         """Find the resource for given parameters.
@@ -1371,6 +1380,7 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
         if PLUGIN_CFG.get("NAUTOBOT_INFOBLOX_NETWORK_VIEW"):
             params.update({"network_view": PLUGIN_CFG["NAUTOBOT_INFOBLOX_NETWORK_VIEW"]})
         params.update({"network_container": prefix})
+
         try:
             response = self._request("GET", url_path, params=params)
         except HTTPError as err:

--- a/nautobot_ssot/integrations/infoblox/utils/client.py
+++ b/nautobot_ssot/integrations/infoblox/utils/client.py
@@ -791,7 +791,8 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
             "_return_fields": "network,network_view,comment,extattrs,rir_organization,rir,vlans",
             "_max_results": 10000,
         }
-
+        if PLUGIN_CFG.get("NAUTOBOT_INFOBLOX_NETWORK_VIEW"):
+            params.update({"network_view": PLUGIN_CFG.get("NAUTOBOT_INFOBLOX_NETWORK_VIEW")})
         if prefix:
             params.update({"network": prefix})
         try:
@@ -1275,6 +1276,8 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
             "_return_fields": "network,comment,network_view,extattrs,rir_organization,rir",
             "_max_results": 100000,
         }
+        if PLUGIN_CFG.get("NAUTOBOT_INFOBLOX_NETWORK_VIEW"):
+            params.update({"network_view": PLUGIN_CFG["NAUTOBOT_INFOBLOX_NETWORK_VIEW"]})
         if prefix:
             params.update({"network": prefix})
         response = self._request("GET", url_path, params=params)
@@ -1317,6 +1320,8 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
             "_return_fields": "network,comment,network_view,extattrs,rir_organization,rir",
             "_max_results": 100000,
         }
+        if PLUGIN_CFG.get("NAUTOBOT_INFOBLOX_NETWORK_VIEW"):
+            params.update({"network_view": PLUGIN_CFG["NAUTOBOT_INFOBLOX_NETWORK_VIEW"]})
         params.update({"network_container": prefix})
         response = self._request("GET", url_path, params=params)
         response = response.json()
@@ -1363,9 +1368,9 @@ class InfobloxApi:  # pylint: disable=too-many-public-methods,  too-many-instanc
             "_return_fields": "network,network_view,comment,extattrs,rir_organization,rir,vlans",
             "_max_results": 10000,
         }
-
+        if PLUGIN_CFG.get("NAUTOBOT_INFOBLOX_NETWORK_VIEW"):
+            params.update({"network_view": PLUGIN_CFG["NAUTOBOT_INFOBLOX_NETWORK_VIEW"]})
         params.update({"network_container": prefix})
-
         try:
             response = self._request("GET", url_path, params=params)
         except HTTPError as err:

--- a/nautobot_ssot/tests/test_contrib.py
+++ b/nautobot_ssot/tests/test_contrib.py
@@ -390,7 +390,7 @@ class BaseModelCustomFieldTest(TestCase):
     def test_custom_field_set(self):
         """Test whether setting a custom field value works."""
         custom_field_name = "Is Global"
-        custom_field = CustomField.objects.create(key=custom_field_name, label=custom_field_name, type="boolean")
+        custom_field = CustomField.objects.create(key="is_global", label=custom_field_name, type="boolean")
         custom_field.content_types.set([ContentType.objects.get_for_model(Provider)])
 
         class ProviderModel(NautobotModel):
@@ -402,7 +402,7 @@ class BaseModelCustomFieldTest(TestCase):
 
             name: str
 
-            is_global: Annotated[bool, CustomFieldAnnotation(name=custom_field_name)] = False
+            is_global: Annotated[bool, CustomFieldAnnotation(name="is_global")] = False
 
         provider_name = "Test Provider"
         provider = Provider.objects.create(name=provider_name)
@@ -413,7 +413,7 @@ class BaseModelCustomFieldTest(TestCase):
 
         provider.refresh_from_db()
         self.assertEqual(
-            provider.cf[custom_field_name],
+            provider.cf["is_global"],
             updated_custom_field_value,
             "Setting a custom field through 'NautobotModel' does not work.",
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-ssot"
-version = "2.0.3"
+version = "2.0.2"
 description = "Nautobot Single Source of Truth"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-ssot"
-version = "2.0.2"
+version = "2.0.3"
 description = "Nautobot Single Source of Truth"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
- Add a new setting to optionally specify a single Network View to load from Infoblox
- Address the possibility of an extensible attribute containing multiple values
- Add support for Nautobot IP address types
- Move debug message `Creating IP Address {addr}` under a debug check to prevent unintended logging
